### PR TITLE
Benchmark and improve

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # prometheus-vmware-exporter
 Collect VMWare metrics from a vSphere host
 
+## Test
+Currently, the only tests available are benchmarks.  To run them, set
+`VSPHERE_HOST`, `VSPHERE_USERNAME`, and `VSPHERE_PASSWORD` in your shell
+environment and run `go test -bench . -benchmem` from the `controller`
+directory.
+
 ## Build
 ```sh 
 docker build -t prometheus-vmware-exporter .

--- a/controller/metrics_test.go
+++ b/controller/metrics_test.go
@@ -28,7 +28,7 @@ func initLogger() (*log.Logger, error) {
 func BenchmarkNewVmwareHostMetrics(b *testing.B) {
 	logger, err := initLogger()
 	if err != nil {
-		panic("Could not set logger for testing")
+		b.Fatalf("Could not set logger for testing: %v", err)
 	}
 
 	for i := 0; i < b.N; i++ {
@@ -39,7 +39,7 @@ func BenchmarkNewVmwareHostMetrics(b *testing.B) {
 func BenchmarkNewVmwareDsMetrics(b *testing.B) {
 	logger, err := initLogger()
 	if err != nil {
-		panic("Could not set logger for testing")
+		b.Fatalf("Could not set logger for testing: %v", err)
 	}
 
 	for i := 0; i < b.N; i++ {
@@ -50,7 +50,7 @@ func BenchmarkNewVmwareDsMetrics(b *testing.B) {
 func BenchmarkNewVmwareVmMetrics(b *testing.B) {
 	logger, err := initLogger()
 	if err != nil {
-		panic("Could not set logger for testing")
+		b.Fatalf("Could not set logger for testing: %v", err)
 	}
 
 	for i := 0; i < b.N; i++ {

--- a/controller/metrics_test.go
+++ b/controller/metrics_test.go
@@ -1,0 +1,71 @@
+package controller
+
+import (
+	"os"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	listen   = ":9879"
+	host     = os.Getenv("VSPHERE_HOST")
+	username = os.Getenv("VSPHERE_USERNAME")
+	password = os.Getenv("VSPHERE_PASSWORD")
+	logLevel = "info"
+)
+
+func initLogger() (*log.Logger, error) {
+	logger := log.New()
+	logrusLogLevel, err := log.ParseLevel(logLevel)
+	if err != nil {
+		return logger, err
+	}
+	logger.SetLevel(logrusLogLevel)
+	logger.Formatter = &log.TextFormatter{DisableTimestamp: false, FullTimestamp: true}
+	return logger, nil
+}
+
+func BenchmarkNewVmwareHostMetrics(b *testing.B) {
+	logger, err := initLogger()
+	if err != nil {
+		panic("Could not set logger for testing")
+	}
+
+	for i := 0; i < b.N; i++ {
+		NewVmwareHostMetrics(host, username, password, logger)
+	}
+}
+
+func BenchmarkNewVmwareDsMetrics(b *testing.B) {
+	logger, err := initLogger()
+	if err != nil {
+		panic("Could not set logger for testing")
+	}
+
+	for i := 0; i < b.N; i++ {
+		NewVmwareDsMetrics(host, username, password, logger)
+	}
+}
+
+func BenchmarkNewVmwareVmMetrics(b *testing.B) {
+	logger, err := initLogger()
+	if err != nil {
+		panic("Could not set logger for testing")
+	}
+
+	for i := 0; i < b.N; i++ {
+		NewVmwareVmMetrics(host, username, password, logger)
+	}
+}
+
+func BenchmarkNewVmwareVmPerfMetrics(b *testing.B) {
+	logger, err := initLogger()
+	if err != nil {
+		panic("Could not set logger for testing")
+	}
+
+	for i := 0; i < b.N; i++ {
+		NewVmwareVmPerfMetrics(host, username, password, logger)
+	}
+}

--- a/controller/metrics_test.go
+++ b/controller/metrics_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 var (
-	listen   = ":9879"
 	host     = os.Getenv("VSPHERE_HOST")
 	username = os.Getenv("VSPHERE_USERNAME")
 	password = os.Getenv("VSPHERE_PASSWORD")
@@ -56,16 +55,5 @@ func BenchmarkNewVmwareVmMetrics(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		NewVmwareVmMetrics(host, username, password, logger)
-	}
-}
-
-func BenchmarkNewVmwareVmPerfMetrics(b *testing.B) {
-	logger, err := initLogger()
-	if err != nil {
-		panic("Could not set logger for testing")
-	}
-
-	for i := 0; i < b.N; i++ {
-		NewVmwareVmPerfMetrics(host, username, password, logger)
 	}
 }


### PR DESCRIPTION
After seeing less than promising performance, I decided to check out any ways to eek out more performant ways of doing things.  After setting up benchmarks, it became readily apparent that using two separate functions to get VM metrics was prohibitively expensive, particularly since there's only really one performance metric we're after in the first place.  So, I tried refactoring the performance metric function into a sub-function that takes many of the data structures from it's parent, drastically reducing memory allocation and improving the speed of metric gathering in the process.

```
➜ go test -bench . -benchmem
goos: darwin
goarch: amd64
pkg: prometheus-vmware-exporter/controller
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkNewVmwareHostMetrics-16      	       2	 792445544 ns/op	 7446024 B/op	  184800 allocs/op
BenchmarkNewVmwareDsMetrics-16        	       3	 483216845 ns/op	  528109 B/op	    4550 allocs/op
BenchmarkNewVmwareVmMetrics-16        	       1	2068735480 ns/op	105484968 B/op	 2237262 allocs/op
BenchmarkNewVmwareVmPerfMetrics-16    	       1	2414433926 ns/op	112015592 B/op	 2377978 allocs/op
PASS
ok  	prometheus-vmware-exporter/controller	11.935s


➜ go test -bench . -benchmem
goos: darwin
goarch: amd64
pkg: prometheus-vmware-exporter/controller
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkNewVmwareHostMetrics-16    	       2	 754349010 ns/op	 7442056 B/op	  184798 allocs/op
BenchmarkNewVmwareDsMetrics-16      	       2	 512897976 ns/op	  536680 B/op	    4557 allocs/op
BenchmarkNewVmwareVmMetrics-16      	       1	2816887761 ns/op	116540512 B/op	 2480360 allocs/op
PASS
ok  	prometheus-vmware-exporter/controller	7.013s
```
The resource usage of `NewVmwareVmMetrics` is slightly raised, but we effectively halve the amount of resources needed by not allocating anything to `NewVmwareVmPerfMetrics`.